### PR TITLE
Set __typename complexity to 0

### DIFF
--- a/lib/absinthe/introspection/field.ex
+++ b/lib/absinthe/introspection/field.ex
@@ -10,6 +10,7 @@ defmodule Absinthe.Introspection.Field do
     %Type.Field{
       name: "__typename",
       type: :string,
+      complexity: 0,
       description: "The name of the object type currently being queried.",
       middleware: [
         Absinthe.Resolution.resolver_spec(fn


### PR DESCRIPTION
This is so requests form the Apollo Client don't unexpectedly hit the complexity ceiling. I don't feel like we have a super compelling reason to make all of introspection free, but I will attach this PR to ticket in the Complexity MMF that says to come back and take a look once we have our complexity strategy more well defined.