### PR TITLE
Update complexity error message

### DIFF
--- a/lib/absinthe/phase/document/complexity/result.ex
+++ b/lib/absinthe/phase/document/complexity/result.ex
@@ -32,7 +32,8 @@ defmodule Absinthe.Phase.Document.Complexity.Result do
     end
   end
 
-  defp handle_node(%{complexity: complexity} = node, max, errors)
+  # Updated to only handle the top level operation so that we can simplify error messaging
+  defp handle_node(%Blueprint.Document.Operation{complexity: complexity} = node, max, errors)
        when is_integer(complexity) and complexity > max do
     error = error(node, complexity, max)
 
@@ -61,22 +62,15 @@ defmodule Absinthe.Phase.Document.Complexity.Result do
   end
 
   def error_message(node, complexity, max) do
-    "#{describe_node(node)} is too complex: complexity is #{complexity} and maximum is #{max}"
+    "#{describe_node(node)} is too complex: you asked for #{complexity} fields and the maximum" <>
+      " is #{max}"
   end
 
-  defp describe_node(%Blueprint.Document.Operation{name: nil}) do
+  defp describe_node(%{name: nil}) do
     "Operation"
   end
 
-  defp describe_node(%Blueprint.Document.Operation{name: name}) do
+  defp describe_node(%{name: name}) do
     "Operation #{name}"
-  end
-
-  defp describe_node(%Blueprint.Document.Field{name: name}) do
-    "Field #{name}"
-  end
-
-  defp describe_node(%Blueprint.Document.Fragment.Spread{name: name}) do
-    "Spread #{name}"
   end
 end

--- a/test/absinthe/phase/document/complexity_test.exs
+++ b/test/absinthe/phase/document/complexity_test.exs
@@ -233,8 +233,7 @@ defmodule Absinthe.Phase.Document.ComplexityTest do
       errors = result.execution.validation_errors |> Enum.map(& &1.message)
 
       assert errors == [
-               "Field fooComplexity is too complex: complexity is 6 and maximum is 5",
-               "Operation ComplexityError is too complex: complexity is 6 and maximum is 5"
+               "Operation ComplexityError is too complex: you asked for 6 fields and the maximum is 5"
              ]
     end
 
@@ -261,8 +260,7 @@ defmodule Absinthe.Phase.Document.ComplexityTest do
       errors = result.execution.validation_errors |> Enum.map(& &1.message)
 
       assert errors == [
-               "Field nestedComplexity is too complex: complexity is 5 and maximum is 4",
-               "Operation ComplexityNested is too complex: complexity is 5 and maximum is 4"
+               "Operation ComplexityNested is too complex: you asked for 5 fields and the maximum is 4"
              ]
     end
 
@@ -281,8 +279,7 @@ defmodule Absinthe.Phase.Document.ComplexityTest do
       errors = result.execution.validation_errors |> Enum.map(& &1.message)
 
       assert errors == [
-               "Field fooComplexity is too complex: complexity is 105 and maximum is 100",
-               "Operation is too complex: complexity is 105 and maximum is 100"
+               "Operation is too complex: you asked for 105 fields and the maximum is 100"
              ]
     end
 


### PR DESCRIPTION
The current complexity error message is very confusing for customers brand new to GraphQL. This is only a temporary solution. It is likely that we will have a better solution once we define our complexity strategy in the Complexity MMF.